### PR TITLE
[0.0.1/2.9.2] 탈퇴시 모달상태 변경 추가

### DIFF
--- a/src/components/page/Mypage/WithdrawModal.vue
+++ b/src/components/page/Mypage/WithdrawModal.vue
@@ -47,6 +47,7 @@ const handlerBtn = () => {
                 alert("탈퇴 되었습니다.\n지금까지 서비스를 이용해주셔서 감사합니다.")
                 userInfo.setAuthenticated();
                 handlerModal();
+                sessionStorage.setItem("userInfo", "");
                 router.push('/');
             } else {
                 alert("비밀번호를 확인해주세요.")

--- a/src/components/page/Mypage/WithdrawModal.vue
+++ b/src/components/page/Mypage/WithdrawModal.vue
@@ -46,6 +46,7 @@ const handlerBtn = () => {
             if (res.data.result === 'success') {
                 alert("탈퇴 되었습니다.\n지금까지 서비스를 이용해주셔서 감사합니다.")
                 userInfo.setAuthenticated();
+                handlerModal();
                 router.push('/');
             } else {
                 alert("비밀번호를 확인해주세요.")
@@ -82,7 +83,7 @@ const handlerModal = () => {
     border-radius: 8px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
     position: relative;
-    width: 400px;
+    width: 500px;
 }
 
 input[type="text"] {


### PR DESCRIPTION
- [x] 회원 탈퇴시 모달 닫기 추가



* 회원 탈퇴 후 메인으로 이동하는 과정에서, 모달을 닫는 코드가 없어서, 이동 후, 메인의 모달이 뜨는 문제가 있었음